### PR TITLE
GitHub ci: Add support for both Intel and Apple Silicon Macs

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -12,7 +12,34 @@ on:
         description: 'Release name'
         required: true
 jobs:
-  macOS:
+  macOS_Intel:
+    runs-on: macos-13
+    steps:
+      - name: 'Checkout Repo'
+        uses: actions/checkout@v4
+
+      - name: Compile
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pyinstaller
+          pyinstaller --onefile --clean main.py
+          chmod a+x ./dist/main
+          mv ./dist/main "./ESET-KeyGen_v${{ github.event.inputs.version }}_macos_amd64"
+
+      - name: Release
+        if: github.ref == 'refs/heads/main'
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            ESET-KeyGen_v${{ github.event.inputs.version }}_macos_amd64
+          name: ${{ github.event.inputs.release_name }}
+          tag_name: v${{ github.event.inputs.tagname }}
+          draft: false
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.PAT }}
+  macOS_Arm:
     runs-on: macos-latest
     steps:
       - name: 'Checkout Repo'
@@ -25,14 +52,14 @@ jobs:
           pip install pyinstaller
           pyinstaller --onefile --clean main.py
           chmod a+x ./dist/main
-          mv ./dist/main "./ESET-KeyGen_v${{ github.event.inputs.version }}_macos"
+          mv ./dist/main "./ESET-KeyGen_v${{ github.event.inputs.version }}_macos_arm64"
 
       - name: Release
         if: github.ref == 'refs/heads/main'
         uses: softprops/action-gh-release@v2
         with:
           files: |
-            ESET-KeyGen_v${{ github.event.inputs.version }}_macos
+            ESET-KeyGen_v${{ github.event.inputs.version }}_macos_arm64
           name: ${{ github.event.inputs.release_name }}
           tag_name: v${{ github.event.inputs.tagname }}
           draft: false

--- a/modules/Updater.py
+++ b/modules/Updater.py
@@ -7,6 +7,7 @@ import zipfile
 import json
 import sys
 import os
+import platform
 
 def parse_update_json(json_path='', from_main=False):
     if json_path == '':
@@ -113,7 +114,9 @@ def update_binary(update_json):
             if sys.maxsize > 2**32: # 64bit 
                 arch = 'win64'
         elif sys.platform == "darwin":
-            arch = 'macos'
+            arch = 'macos_arm64'
+            if platform.machine() == "x86_64":
+                arch = 'macos_amd64'
         # downloading
         if arch != '':
             for asset_name, asset_url in assets.items():


### PR DESCRIPTION
GitHub changed the macos-latest runner image to M1 Macs. macOS 13 uses Intel.