### PR TITLE
Fix: improve headless Chromium stability and declare PROXY_ERROR_COUNTER_LIMIT as global

### DIFF
--- a/main.py
+++ b/main.py
@@ -389,6 +389,7 @@ def update():
     exit_program(0)
 
 def main(disable_exit=False):
+    global PROXY_ERROR_COUNTER_LIMIT
     global PROXY_ERROR_COUNTER
     global DRIVER
     if args['return_exit_code'] != 0:

--- a/modules/SharedTools.py
+++ b/modules/SharedTools.py
@@ -298,9 +298,11 @@ def initSeleniumWebDriver(browser_name: str, webdriver_path = None, browser_path
         driver_options.add_argument(f"--load-extension={chrome_proxy_extension_path}")
         if headless:
             driver_options.add_argument('--headless')
+            driver_options.add_argument('--remote-debugging-port=9222')  # Fix for DevToolsActivePort in Linux headless
         if os.name == 'posix': # For Linux
             driver_options.add_argument('--no-sandbox')
             driver_options.add_argument('--disable-dev-shm-usage')
+            driver_options.add_argument('--disable-gpu') # Add for stability
         try:
             service = ChromeService(executable_path=webdriver_path)
             if os.name == 'nt' and headless:


### PR DESCRIPTION
## Problem

In Linux-based headless environments (e.g. snap Chromium, virtual machines, Docker, CI/CD), Selenium often fails to start Chromium due to:

> DevToolsActivePort file doesn't exist

Additionally, the global variable `PROXY_ERROR_COUNTER_LIMIT` caused `UnboundLocalError` when modified in `main()`.

## Fix

- Added `--remote-debugging-port=9222` to ChromeOptions in headless mode
- Added `--disable-gpu` for increased stability in virtualized headless environments
- Declared `PROXY_ERROR_COUNTER_LIMIT` as global to ensure proper scope when incremented

## Tested

- Ubuntu 22.04
- snap Chromium v136.0.7103.92
- Python 3.12 + Selenium 4.19
